### PR TITLE
Fix Google Cast initialization

### DIFF
--- a/lib/custom_code/actions/initialize_google_cast.dart
+++ b/lib/custom_code/actions/initialize_google_cast.dart
@@ -7,8 +7,7 @@ import 'package:flutter/material.dart';
 // DO NOT REMOVE OR MODIFY THE CODE ABOVE!
 
 import 'dart:io';
-import 'package:flutter_chrome_cast/cast_context.dart';
-import 'package:flutter_chrome_cast/discovery.dart';
+import 'package:flutter_chrome_cast/flutter_chrome_cast.dart';
 
 /// Flag to ensure initialization happens only once.
 bool isCastInitialized = false;
@@ -21,7 +20,7 @@ Future<void> initializeGoogleCast() async {
   }
 
   const appId = GoogleCastDiscoveryCriteria.kDefaultApplicationId;
-  GoogleCastOptions? options;
+  late final GoogleCastOptions options;
   if (Platform.isIOS) {
     options = IOSGoogleCastOptions(
       GoogleCastDiscoveryCriteriaInitialize.initWithApplicationID(appId),
@@ -30,6 +29,6 @@ Future<void> initializeGoogleCast() async {
     options = GoogleCastOptionsAndroid(appId: appId);
   }
 
-  GoogleCastContext.instance.setSharedInstanceWithOptions(options!);
+  await GoogleCastContext.instance.setSharedInstanceWithOptions(options);
   isCastInitialized = true;
 }


### PR DESCRIPTION
## Summary
- import the full Google Cast library and await initialization
- simplify Google Cast option selection for iOS and Android

## Testing
- `dart format lib/custom_code/actions/initialize_google_cast.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_688fb9009fc8832d99f55cbb52d28c40