### PR TITLE
fix: resolve CastMediaControlIntent import

### DIFF
--- a/android/app/src/main/kotlin/com/example/my_project/CastOptionsProvider.kt
+++ b/android/app/src/main/kotlin/com/example/my_project/CastOptionsProvider.kt
@@ -2,9 +2,9 @@ package br.com.massdev.appversum
 
 import android.content.Context
 import com.google.android.gms.cast.framework.CastOptions
-import com.google.android.gms.cast.framework.CastMediaControlIntent
 import com.google.android.gms.cast.framework.OptionsProvider
 import com.google.android.gms.cast.framework.SessionProvider
+import com.google.android.gms.cast.CastMediaControlIntent
 
 class CastOptionsProvider : OptionsProvider {
     override fun getCastOptions(context: Context): CastOptions {


### PR DESCRIPTION
## Summary
- fix unresolved reference for CastMediaControlIntent by importing from correct package

## Testing
- `gradle -p android assembleDebug` *(fails: /workspace/app_versum_2/android/local.properties (No such file or directory))*

------
https://chatgpt.com/codex/tasks/task_e_688fbe21826c832daeb44c62b996699d