### PR TITLE
Start cast device discovery and update cast button color

### DIFF
--- a/lib/custom_code/actions/initialize_google_cast.dart
+++ b/lib/custom_code/actions/initialize_google_cast.dart
@@ -30,5 +30,6 @@ Future<void> initializeGoogleCast() async {
   }
 
   await GoogleCastContext.instance.setSharedInstanceWithOptions(options);
+  await GoogleCastDiscoveryManager.instance.startDiscovery();
   isCastInitialized = true;
 }

--- a/lib/custom_code/widgets/cast_button_widget.dart
+++ b/lib/custom_code/widgets/cast_button_widget.dart
@@ -29,7 +29,7 @@ class _CastButtonWidgetState extends State<CastButtonWidget> {
         return IconButton(
           icon: Icon(
             connected ? Icons.cast_connected : Icons.cast,
-            color: FlutterFlowTheme.of(context).primaryText,
+            color: Colors.white,
           ),
           onPressed: () async {
             if (connected) {


### PR DESCRIPTION
## Summary
- make cast button use a white icon
- start cast device discovery during initialization so devices show up

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fbff44a88832d8b20a7dc5f9bb4c9