### PR TITLE
Load video onto Chromecast after device selection

### DIFF
--- a/lib/custom_code/widgets/cast_button_widget.dart
+++ b/lib/custom_code/widgets/cast_button_widget.dart
@@ -12,7 +12,21 @@ import 'package:flutter_chrome_cast/flutter_chrome_cast.dart';
 /// Button that allows the user to connect to a Google Cast device and
 /// start or stop a cast session.
 class CastButtonWidget extends StatefulWidget {
-  const CastButtonWidget({Key? key}) : super(key: key);
+  const CastButtonWidget({
+    Key? key,
+    this.videoUrl,
+    this.title,
+    this.image,
+  }) : super(key: key);
+
+  /// Url of the video to be cast to the remote device.
+  final String? videoUrl;
+
+  /// Optional title shown on the cast device.
+  final String? title;
+
+  /// Optional preview image for the video.
+  final String? image;
 
   @override
   State<CastButtonWidget> createState() => _CastButtonWidgetState();
@@ -55,6 +69,17 @@ class _CastButtonWidgetState extends State<CastButtonWidget> {
               if (device != null) {
                 await GoogleCastSessionManager.instance
                     .startSessionWithDevice(device);
+                // Wait for the session to be established before casting media.
+                await GoogleCastSessionManager.instance.currentSessionStream
+                    .firstWhere((session) => session != null);
+
+                if (widget.videoUrl != null) {
+                  await castVideo(
+                    url: widget.videoUrl!,
+                    title: widget.title,
+                    image: widget.image,
+                  );
+                }
               }
             }
           },

--- a/lib/pages/home_page/home_page_widget.dart
+++ b/lib/pages/home_page/home_page_widget.dart
@@ -58,8 +58,14 @@ class _HomePageWidgetState extends State<HomePageWidget> {
           backgroundColor: Colors.black,
           automaticallyImplyLeading: false,
           elevation: 0.0,
-          actions: const [
-            CastButtonWidget(),
+          actions: [
+            CastButtonWidget(
+              videoUrl:
+                  'https://storage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+              title: 'Big Buck Bunny',
+              image:
+                  'https://storage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg',
+            ),
           ],
         ),
         body: SafeArea(


### PR DESCRIPTION
## Summary
- send video URL to Chromecast device after session start
- pass sample video information from HomePage to cast button
- wait for cast session to initialize before loading media

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688fc34a1254832da4c6067886bcc97f