### PR TITLE
fix: update WebView URL request

### DIFF
--- a/lib/custom_code/widgets/persistent_web_view.dart
+++ b/lib/custom_code/widgets/persistent_web_view.dart
@@ -35,7 +35,7 @@ class _PersistentWebViewState extends State<PersistentWebView> {
       height: widget.height,
       child: InAppWebView(
         initialUrlRequest: widget.initialUrl != null
-            ? URLRequest(url: Uri.parse(widget.initialUrl!))
+            ? URLRequest(url: WebUri(widget.initialUrl!))
             : null,
         onWebViewCreated: (controller) {
           _controller = controller;


### PR DESCRIPTION
## Summary
- use `WebUri` when creating `URLRequest` so the persistent web view handles initial URL correctly

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install flutter` *(fails: Unable to locate package)*
- `apt-get install dart` *(fails: Unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fd3843140832db5608e1bbec63668