### PR TITLE
Add cast shim to prevent WebView crash

### DIFF
--- a/lib/flutter_flow/flutter_flow_web_view.dart
+++ b/lib/flutter_flow/flutter_flow_web_view.dart
@@ -36,6 +36,8 @@ class FlutterFlowWebView extends StatefulWidget {
 }
 
 class _FlutterFlowWebViewState extends State<FlutterFlowWebView> {
+  WebViewXController? _controller;
+
   @override
   Widget build(BuildContext context) => WebViewX(
         key: webviewKey,
@@ -52,11 +54,15 @@ class _FlutterFlowWebViewState extends State<FlutterFlowWebView> {
                 : SourceType.url,
         javascriptMode: JavascriptMode.unrestricted,
         onWebViewCreated: (controller) async {
+          _controller = controller;
           if (controller.connector is WebViewController && isAndroid) {
             final androidController =
                 controller.connector.platform as AndroidWebViewController;
             await androidController.setOnShowFileSelector(_androidFilePicker);
           }
+        },
+        onPageFinished: (_) async {
+          await _injectCastShim();
         },
         navigationDelegate: (request) async {
           if (isAndroid) {
@@ -115,5 +121,16 @@ class _FlutterFlowWebViewState extends State<FlutterFlowWebView> {
       return [file.uri.toString()];
     }
     return [];
+  }
+
+  Future<void> _injectCastShim() async {
+    try {
+      await _controller?.evalRawJavascript(
+        'if (typeof window.cast === "undefined") { window.cast = {}; }',
+        inGlobalContext: true,
+      );
+    } catch (_) {
+      // Ignore errors from script evaluation
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Inject JavaScript shim in WebView to provide a `cast` object when the Cast API is absent

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fdc227a58832db5203deb7efdf8b4