### PR TITLE
Invoke requestAndCastVideo from Cast button

### DIFF
--- a/lib/custom_code/actions/request_and_cast_video.dart
+++ b/lib/custom_code/actions/request_and_cast_video.dart
@@ -11,9 +11,14 @@ import 'package:http/http.dart' as http;
 
 /// Requests the current video URL from a backend service and casts it.
 Future<void> requestAndCastVideo({
-  String endpoint = 'http://localhost:8080/current-video',
+  // Use an accessible host for emulators or physical devices instead of
+  // `localhost`. `10.0.2.2` points to the host machine when running on the
+  // Android emulator.
+  String endpoint = 'http://10.0.2.2:8080/current-video',
 }) async {
+  debugPrint('Requesting video from: $endpoint');
   final response = await http.get(Uri.parse(endpoint));
+  debugPrint('Response status: ${response.statusCode}');
 
   if (response.statusCode != 200) {
     throw Exception('Failed to load video URL');
@@ -21,6 +26,7 @@ Future<void> requestAndCastVideo({
 
   final data = jsonDecode(response.body) as Map<String, dynamic>;
   final url = data['url'] as String?;
+  debugPrint('Received URL: $url');
 
   if (url == null) {
     throw Exception('URL not found in response');

--- a/lib/custom_code/widgets/cast_button_widget.dart
+++ b/lib/custom_code/widgets/cast_button_widget.dart
@@ -55,6 +55,9 @@ class _CastButtonWidgetState extends State<CastButtonWidget> {
               if (device != null) {
                 await GoogleCastSessionManager.instance
                     .startSessionWithDevice(device);
+                // After establishing a session, request the current video
+                // from the backend and start casting it.
+                await requestAndCastVideo();
               }
             }
           },


### PR DESCRIPTION
## Summary
- Call `requestAndCastVideo` after establishing a Cast session via the Cast button
- Log video request details and switch default endpoint to an accessible host (10.0.2.2)

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*


------
https://chatgpt.com/codex/tasks/task_e_688ff7533174832da186f7c3562c2841