### PR TITLE
Expose configurable backend URL and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,24 @@ A new Flutter project.
 ## Getting Started
 
 FlutterFlow projects are built to run on the Flutter _stable_ release.
+
+## Configuring the backend endpoint
+
+The app retrieves the current video URL from a backend service. The base URL
+is read from the `SERVER_URL` compile-time environment variable and defaults to
+`http://10.0.2.2:8080`.
+
+Run the app with a custom server URL:
+
+```bash
+flutter run --dart-define=SERVER_URL=http://<host>:<port>
+```
+
+Platform specific hosts:
+
+- **Android emulator** – `http://10.0.2.2:<port>` points to the host machine.
+- **iOS simulator** – `http://localhost:<port>` reaches the host machine.
+- **Physical devices** – use your machine's IP address, e.g.
+  `http://192.168.1.100:<port>`.
+
+The app requests the current video from `${SERVER_URL}/current-video`.

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,0 +1,12 @@
+class AppConfig {
+  /// Base URL for the backend server. The value can be overridden at build
+  /// time using the `SERVER_URL` compile-time environment variable:
+  /// `flutter run --dart-define=SERVER_URL=http://<your-host>:<port>`.
+  static const String serverUrl = String.fromEnvironment(
+    'SERVER_URL',
+    defaultValue: 'http://10.0.2.2:8080',
+  );
+
+  /// Endpoint used to request the current video URL.
+  static String get currentVideoEndpoint => '$serverUrl/current-video';
+}

--- a/lib/custom_code/actions/request_and_cast_video.dart
+++ b/lib/custom_code/actions/request_and_cast_video.dart
@@ -8,16 +8,19 @@ import 'package:flutter/material.dart';
 
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'package:app_versum/config/app_config.dart';
 
 /// Requests the current video URL from a backend service and casts it.
 Future<void> requestAndCastVideo({
-  // Use an accessible host for emulators or physical devices instead of
-  // `localhost`. `10.0.2.2` points to the host machine when running on the
-  // Android emulator.
-  String endpoint = 'http://10.0.2.2:8080/current-video',
+  /// Optional override for the backend endpoint. By default the value from
+  /// [AppConfig.currentVideoEndpoint] is used, which can be set at build time
+  /// via the `SERVER_URL` environment variable.
+  String? endpoint,
 }) async {
-  debugPrint('Requesting video from: $endpoint');
-  final response = await http.get(Uri.parse(endpoint));
+  final resolvedEndpoint = endpoint ?? AppConfig.currentVideoEndpoint;
+
+  debugPrint('Requesting video from: $resolvedEndpoint');
+  final response = await http.get(Uri.parse(resolvedEndpoint));
   debugPrint('Response status: ${response.statusCode}');
 
   if (response.statusCode != 200) {


### PR DESCRIPTION
## Summary
- load backend URL from a compile-time `SERVER_URL` env var
- default to Android emulator host and allow override in `requestAndCastVideo`
- document platform-specific endpoint settings

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688fffc3e62c832dbfa6cbb2bb21486b