### PR TITLE
fix: prevent reload on iOS orientation change

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -46,15 +46,10 @@
     <key>UISupportedInterfaceOrientations</key>
     <array>
       <string>UIInterfaceOrientationPortrait</string>
-      <string>UIInterfaceOrientationLandscapeLeft</string>
-      <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
     <key>UISupportedInterfaceOrientations~ipad</key>
     <array>
       <string>UIInterfaceOrientationPortrait</string>
-      <string>UIInterfaceOrientationPortraitUpsideDown</string>
-      <string>UIInterfaceOrientationLandscapeLeft</string>
-      <string>UIInterfaceOrientationLandscapeRight</string>
     </array>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <false/>


### PR DESCRIPTION
## Summary
- lock iOS orientation to portrait so the app doesn't restart when rotating the device

## Testing
- `flutter test --suppress-analytics` *(fails: tool hangs after resolving dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6890d412569c832da95b31393c0291d1