### PR TITLE
Remove empty app bar for full screen home page

### DIFF
--- a/lib/pages/home_page/home_page_widget.dart
+++ b/lib/pages/home_page/home_page_widget.dart
@@ -24,7 +24,6 @@ class _HomePageWidgetState extends State<HomePageWidget> {
   void initState() {
     super.initState();
     _model = createModel(context, () => HomePageModel());
-
   }
 
   @override
@@ -44,25 +43,17 @@ class _HomePageWidgetState extends State<HomePageWidget> {
       child: Scaffold(
         key: scaffoldKey,
         backgroundColor: Colors.black,
-        appBar: AppBar(
-          backgroundColor: Colors.black,
-          automaticallyImplyLeading: false,
-          elevation: 0.0,
-        ),
-        body: SafeArea(
-          top: true,
-          child: Stack(
-            children: [
-              FlutterFlowWebView(
-                content: 'https://app-versum.web.app/',
-                bypass: false,
-                width: MediaQuery.sizeOf(context).width * 1.0,
-                height: MediaQuery.sizeOf(context).height * 1.0,
-                verticalScroll: false,
-                horizontalScroll: false,
-              ),
-            ],
-          ),
+        body: Stack(
+          children: [
+            FlutterFlowWebView(
+              content: 'https://app-versum.web.app/',
+              bypass: false,
+              width: MediaQuery.sizeOf(context).width * 1.0,
+              height: MediaQuery.sizeOf(context).height * 1.0,
+              verticalScroll: false,
+              horizontalScroll: false,
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- remove unused `AppBar` and `SafeArea` from home page so content fills entire screen

## Testing
- `dart format lib/pages/home_page/home_page_widget.dart`
- `flutter test` *(fails: process hung while building Flutter tool)*
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_68911848719c832db444ad01cdc38121